### PR TITLE
fix: README typo to clone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Key Details:
 
 Clone the repository:
 ```bash
-git clone https://github.com/CedricCaruzzo/pannuke-segmentation/.git
+git clone https://github.com/CedricCaruzzo/pannuke-segmentation
 cd pannuke-segmentation
 ```
 


### PR DESCRIPTION
# :grey_question: About

I'm trying to boot the streamlit app but the clone script has a typo. 
:point_right:  This PR will fix that

Still, the [Installation phase](https://github.com/CedricCaruzzo/pannuke-segmentation?tab=readme-ov-file#installation) fails with the actual script : 

```sh
python -m venv venv
source venv/bin/activate 
pip install -r requirements.yaml
```

... as `requirements.yaml` does not exist: 

![image](https://github.com/user-attachments/assets/548fcccc-d60e-4b9f-8c0a-787c6c2d83c9)
